### PR TITLE
Fix readme typo: stirngify -> stringify

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ npm install --save json-sorted-stringify
 ```ts
 import stringify from 'json-sorted-stringify';
 
-stirngify ({ a: 1, b: 2 }); // => '{"a":1,"b":2}'
-stirngify ({ b: 2, a: 1 }); // => '{"a":1,"b":2}'
+stringify ({ a: 1, b: 2 }); // => '{"a":1,"b":2}'
+stringify ({ b: 2, a: 1 }); // => '{"a":1,"b":2}'
 ```
 
 ## License


### PR DESCRIPTION
The readme.md had imported the default function as `stringify` but called it as `stirngify`. This quick PR fixes the discrepancy so that the example code will run without needing to be adjusted.

Have a great rest of your day!